### PR TITLE
Fix uninitialized read in wolfMQTTFuzzer::subscribe

### DIFF
--- a/fuzzer.cpp
+++ b/fuzzer.cpp
@@ -101,7 +101,7 @@ Topics::~Topics() {
 }
         
 bool Topics::Generate(void) {
-    bool ret;
+    bool ret = false;
 
     try {
         const auto numTopics = ds.Get<uint16_t>() % (MAX_TOPICS+1);


### PR DESCRIPTION
MSan report from running this oss-fuzz:

```
==637442==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x535760 in wolfMQTTFuzzer::subscribe() /src/wolfmqtt-fuzzers/fuzzer.cpp:240:9
    #1 0x53f9af in wolfMQTTFuzzer::Run() /src/wolfmqtt-fuzzers/fuzzer.cpp:477:21
    #2 0x5419a2 in LLVMFuzzerTestOneInput /src/wolfmqtt-fuzzers/fuzzer.cpp:541:12
    #3 0x4550a3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #4 0x440d32 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #5 0x44657c in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #6 0x46f172 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #7 0x7fa8687f10b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16
    #8 0x41f55d in _start (/home/fuzzer/oss-fuzz/build/out/wolfmqtt/wolfmqtt-fuzzer+0x41f55d)

  Uninitialized value was stored to memory at
    #0 0x532d4e in Topics::Generate() /src/wolfmqtt-fuzzers/fuzzer.cpp:118:5
    #1 0x5356b3 in wolfMQTTFuzzer::subscribe() /src/wolfmqtt-fuzzers/fuzzer.cpp:240:9
    #2 0x53f9af in wolfMQTTFuzzer::Run() /src/wolfmqtt-fuzzers/fuzzer.cpp:477:21
    #3 0x5419a2 in LLVMFuzzerTestOneInput /src/wolfmqtt-fuzzers/fuzzer.cpp:541:12
    #4 0x4550a3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #5 0x440d32 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #6 0x44657c in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #7 0x46f172 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #8 0x7fa8687f10b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was created by an allocation of 'ret' in the stack frame of function '_ZN6Topics8GenerateEv'
    #0 0x531f30 in Topics::Generate() /src/wolfmqtt-fuzzers/fuzzer.cpp:103
```

Bug in question:

```lang=c++
bool Topics::Generate(void) {
    bool ret;

    try { // NOTE: If this throws we never initialize `ret` before returning.
        const auto numTopics = ds.Get<uint16_t>() % (MAX_TOPICS+1);

        for (size_t i = 0; i < numTopics; i++) {
            topics.push_back(new Topic(ds));
            CHECK_EQ(topics.back()->Generate(), true);
        }

        ret = true;
    } catch ( ... ) { }

end:
    return ret;
}
```